### PR TITLE
Feat: 로그아웃 기능 및 모달 버튼에 로그아웃 연동(#131)

### DIFF
--- a/src/components/common/Logout.jsx
+++ b/src/components/common/Logout.jsx
@@ -1,0 +1,29 @@
+import { useRecoilState } from "recoil";
+import accountname from "../../recoil/accountname";
+import logoutCheck from "../../recoil/logoutCheck";
+import { loginCheck } from "../../recoil/loginCheck";
+import loginToken from "../../recoil/loginToken";
+import { useNavigate } from "react-router-dom";
+
+export default function LogoutHandler() {
+  const navigate = useNavigate();
+
+  const [isloginCheck, setLoginCheck] = useRecoilState(loginCheck);
+  const [_loginToken, setToken] = useRecoilState(loginToken);
+  const [_accountname, setAccountname] = useRecoilState(accountname);
+  const [_logoutCheck, setLogoutCheck] = useRecoilState(logoutCheck);
+
+  const handleLogout = () => {
+    setLoginCheck(false);
+    setToken(null);
+    setAccountname("");
+    setLogoutCheck(true);
+
+    navigate("/login");
+  };
+
+  return {handleLogout};
+}
+
+//useSetRecoilState
+//const setPaymentFilter = useSetRecoilState(paymentFilterAtom);

--- a/src/components/common/Modal.jsx
+++ b/src/components/common/Modal.jsx
@@ -2,6 +2,10 @@ import styled from "styled-components";
 import Button from "./Button";
 import CloseButton from "../../assets/close-button.svg";
 import { useState, useEffect } from "react";
+import LogoutHandler from "./Logout";
+import { useRecoilState } from "recoil";
+import { loginCheck } from "../../recoil/loginCheck";
+
 
 export default function Modal({
   text,
@@ -13,6 +17,9 @@ export default function Modal({
   handleModal,
   ...props
 }) {
+  // const handleLogout = LogoutHandler().handleLogout;
+  const {handleLogout} = LogoutHandler()
+
   useEffect(() => {
     // modal이 떠 있을 땐 스크롤 막음
     disableScroll();
@@ -33,6 +40,12 @@ export default function Modal({
   const handleModalClick = (e) => {
     e.stopPropagation();
   };
+  // const handleLogout = LogoutHandler();
+  // const [isloginCheck, setIsLoginCheck] = useRecoilState(loginCheck);
+  // if (isloginCheck) {
+  //   handleLogout();
+  //   setIsLoginCheck(false);
+  // }
 
   return (
     <>
@@ -41,7 +54,7 @@ export default function Modal({
           <ModalInner>
             <span>{text}</span>
             <div>
-              <Button width="100%" text={buttonText1} />
+              <Button width="100%" text={buttonText1} onClick={handleLogout} />
               <Button
                 width="100%"
                 bg="white"

--- a/src/recoil/logoutCheck.js
+++ b/src/recoil/logoutCheck.js
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
+
+const logoutCheck = atom({
+  key: 'logoutCheck',
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+});
+
+export default logoutCheck ;
+
+// 노필요


### PR DESCRIPTION
- 리코일 폴더에 logoutCheck는 필요 없어서 추후 삭제할 예정입니다. (loginCheck의 true, false로만 관리할 예정)
- 일단은 모달 컴포넌트 자체의 첫번째 버튼이 로그아웃 기능을 가지도록 해놨습니다. 후에 사용되는 위치에 따라 children을 이용해서 기능을 달리 가질 수 있도록 할 예정입니다.