### PR TITLE
Feat: 프로필 수정 후 수정 상태 유지(#119)

### DIFF
--- a/src/api/updateProfile.js
+++ b/src/api/updateProfile.js
@@ -1,6 +1,6 @@
 const updateProfile = async (profileData, token) => {
   try {
-    const UPDATEPROFILE = "https://api.mandarin.weniv.co.kr/user/login"
+    const UPDATEPROFILE = "https://api.mandarin.weniv.co.kr/user"
 
     const response = await fetch(UPDATEPROFILE, {
       method: 'PUT',

--- a/src/components/UpdateProfile.jsx
+++ b/src/components/UpdateProfile.jsx
@@ -6,7 +6,7 @@ import { InputBox } from './common/Input';
 import ProfileImgDef from "../assets/profile_img_def.svg";
 import PlusBtnImg from "../assets/add_button.svg";
 
-export default function UpdateProfile({ handleSaveClick, editedProfileData, handleInputChange, handleCancelClick }) {
+export default function UpdateProfile({ handleSaveClick, profileData, handleInputChange, handleCancelClick }) {
 
   return (
     <>
@@ -38,7 +38,7 @@ export default function UpdateProfile({ handleSaveClick, editedProfileData, hand
             height="48px"
             padding="15px"
             name="username"
-            value={editedProfileData.username}
+            value={profileData.user.username}
             onChange={handleInputChange}
             placeholder="변경할 닉네임을 입력해주세요"
           />
@@ -48,7 +48,7 @@ export default function UpdateProfile({ handleSaveClick, editedProfileData, hand
           <textarea
             placeholder="소개 글을 입력해주세요"
             name="intro"
-            value={editedProfileData.intro}
+            value={profileData.user.intro}
             onChange={handleInputChange}
           ></textarea>
         </div>

--- a/src/components/UpdateProfile.jsx
+++ b/src/components/UpdateProfile.jsx
@@ -6,7 +6,7 @@ import { InputBox } from './common/Input';
 import ProfileImgDef from "../assets/profile_img_def.svg";
 import PlusBtnImg from "../assets/add_button.svg";
 
-export default function UpdateProfile({ handleSaveClick, editedProfileData, handleInputChange }) {
+export default function UpdateProfile({ handleSaveClick, editedProfileData, handleInputChange, handleCancelClick }) {
 
   return (
     <>
@@ -52,6 +52,16 @@ export default function UpdateProfile({ handleSaveClick, editedProfileData, hand
             onChange={handleInputChange}
           ></textarea>
         </div>
+        <Button
+          text="수정 취소"
+          type="button"
+          bg="white"
+          color="black"
+          width="100%"
+          padding="14px 0"
+          fontSize="16px"
+          onClick={handleCancelClick}
+        />
         <Button
           text="수정 완료"
           type="submit"
@@ -101,7 +111,11 @@ const Form = styled.form`
   }
 
   button {
-    margin-top: 40px;
+    margin-top: 30px;
+
+    &:last-child {
+      margin-top: 15px;
+    }
   }
 `
 

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -49,13 +49,9 @@ export default function Profile(props) {
   const [followerData, setFollowerData] = useState(null);
 
   // 프로필 정보 수정
-  const { user_image, user_name, user_intro } = props;
   const [isEditing, setIsEditing] = useState(false);
-  const [editedProfileData, setEditedProfileData] = useState({
-    image: user_image,
-    username: user_name,
-    intro: user_intro,
-  });
+  const [editedProfileData, setEditedProfileData] = useState({});
+
 
   // 프로필 정보 API 연동
   useEffect(() => {
@@ -75,9 +71,6 @@ export default function Profile(props) {
   // 팔로워, 팔로잉 API 연동
   useEffect(() => {
     fetchFollowingData(activeFollow);
-  }, [activeFollow]);
-
-  useEffect(() => {
     fetchFollowerData(activeFollow);
   }, [activeFollow]);
 
@@ -145,14 +138,17 @@ export default function Profile(props) {
   // 저장 버튼 클릭 시 수정된 API에 데이터 전달
   const handleSaveClick = (e) => {
     e.preventDefault();
+
     const updatedProfileData = {
       ...profileData,
       user: {
         ...profileData.user,
-        ...editedProfileData
-      }
+        ...editedProfileData.user,
+      },
     };
-    updateProfile(updatedProfileData, token);
+
+    setEditedProfileData(updatedProfileData)
+    updateProfile(profileData, token);
     setIsEditing(false);
   };
 
@@ -165,7 +161,7 @@ export default function Profile(props) {
             <ProfileLeft edit="true">
               <UpdateProfile
                 handleSaveClick={handleSaveClick}
-                editedProfileData={editedProfileData}
+                profileData={profileData}
                 handleInputChange={handleInputChange}
                 handleCancelClick={handleCancelClick}
               />

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -125,6 +125,11 @@ export default function Profile(props) {
     setIsEditing(true);
   };
 
+  // 프로필 수정 취소 이벤트
+  const handleCancelClick = () => {
+    setIsEditing(false);
+  };
+
   // input 값 올바르게 받기
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -162,6 +167,7 @@ export default function Profile(props) {
                 handleSaveClick={handleSaveClick}
                 editedProfileData={editedProfileData}
                 handleInputChange={handleInputChange}
+                handleCancelClick={handleCancelClick}
               />
             </ProfileLeft>
           ) : (
@@ -265,7 +271,7 @@ const ProfileWrap = styled.div`
 
 const ProfileLeft = styled.section`
   width: 100%;
-  max-height: ${(props) => props.edit ? "620px" : "900px"};;
+  max-height: ${(props) => props.edit ? "670px" : "900px"};;
   /* 페이지 네이션 추가 필요 */
   padding: 60px 24px 45px;
   background-color: #fff;


### PR DESCRIPTION
프로필 수정 컴포넌트에 수정 취소 버튼을 추가하였습니다.
프로필 수정 후 새로고침 시 반영이 안되는 이슈를 해결하였습니다. 
- setEditedProfileData에 변경 사항 updatedProfileData 연결 후 updateProfile API에 전송하여 해결
- 이슈 번호: #119 