### PR TITLE
Feat: 게시글 이미지 한 장 이상 넣었을 때 오류, 스플릿처리 (#126)

### DIFF
--- a/src/components/common/PostList.jsx
+++ b/src/components/common/PostList.jsx
@@ -42,7 +42,7 @@ console.log({userPostList})
             profileImage={post.author.image}
             email={""}
             content={post.content}
-            image={BASE_URL + post.image}
+            image={BASE_URL + post.image.split(',')[0]}
             createdAt={post.createdAt}
           />
         ))


### PR DESCRIPTION
- 보여주는 영역은 사진 한 장인데, 사진을 한 장이상 넣을 시 배열로 합쳐져서 이미지 주소가 쏴지기 때문에, split(',')[0] 처리