### PR TITLE
Fix: 이미지 Update 이슈, 프로필 수정 취소 이슈 해결(#155)

### DIFF
--- a/src/profileTest/FollowUI.jsx
+++ b/src/profileTest/FollowUI.jsx
@@ -25,14 +25,13 @@ export default function FollowUI({ profileData }) {
   // 팔로워, 팔로잉 활성화
   const handleFollowClick = (followNumber) => {
     setActiveFollow(followNumber);
-    fetchFollowerData(followNumber);
-    fetchFollowingData(followNumber);
+    followNumber === 1 ? fetchFollowerData() : fetchFollowingData();
   };
 
   // 팔로워, 팔로잉 API 연동
   useEffect(() => {
-    fetchFollowingData(followingData);
-    fetchFollowerData(followerData);
+    fetchFollowingData();
+    fetchFollowerData();
   }, [activeFollow]);
 
   const fetchFollowingData = async () => {

--- a/src/profileTest/UpdateProfile.jsx
+++ b/src/profileTest/UpdateProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components';
 
 import PlusBtnImg from "../assets/add_button.svg";
@@ -18,7 +18,9 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
   const token = useRecoilValue(loginToken);
 
   // 프로필 이미지 업로드
-  const [changeImageURL, setChangeImageURL] = useState("");
+  const [changeImageURL, setChangeImageURL] = useState(profileData.user.image);
+  const [userName, setUserName] = useState(profileData.user.username);
+  const [intro, setIntro] = useState(profileData.user.intro);
 
   // 이미지 fetch
   const BASE_URL = "https://api.mandarin.weniv.co.kr/";
@@ -40,11 +42,13 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
       user: {
         ...profileData.user,
         image: changeImageURL,
+        username: userName,
+        intro: intro
       },
     };
 
     setProfileData(updatedProfileData);
-    updateProfile(profileData, token);
+    updateProfile(updatedProfileData, token);
     setIsEditing(false);
   };
 
@@ -58,16 +62,12 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
   // input 값 올바르게 받기
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setProfileData(prevState => ({
-      ...prevState,
-      user: {
-        ...prevState.user,
-        [name]: value
-      }
-    }));
-  };
-
-  console.log(profileData);
+    if (name === "username") {
+      setUserName(value)
+    } else {
+      setIntro(value)
+    }
+  }
 
   return (
     <>
@@ -102,7 +102,7 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
             height="48px"
             padding="15px"
             name="username"
-            value={profileData.user.username}
+            value={userName}
             onChange={handleInputChange}
             placeholder="변경할 닉네임을 입력해주세요"
           />
@@ -112,7 +112,7 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
           <textarea
             placeholder="소개 글을 입력해주세요"
             name="intro"
-            value={profileData.user.intro}
+            value={intro}
             onChange={handleInputChange}
           ></textarea>
         </div>


### PR DESCRIPTION
1. 이미지 새로고침 시 업데이트가 안되는 문제
- `updateProfile(updatedProfileData, token);` updateProfile에 넣어줄 때 업데이트 된 값인 updatedProfileData를 넣어주어야 했음
2. 수정 취소를 눌렀을 때 업데이트된 값이 출력되는 문제
- input 에 `value={profileData.user.username}` 형식으로 넣다보니 `onChange={handleImageChange}`에서 그때마다 setProfileData가 실행되어 바뀐 값이 profileData에 들어가 저장되었음
3. 프로필 수정 시 사진을 넣지 않고 수정 완료 버튼을 누르면 이미지 경로가 null 처리 되어 있던 문제
- 이미지를 관리하는 state 기본 값을 `profileData.user.image`로 설정하여 데이터가 안들어가도 전 데이터 이미지가 존재하도록 변경

🚫 컴포넌트에서 너무 많은 리렌더링 발생 -> memo를 공부해서 사용하던가 해야될 듯
- 이슈번호: #155 