### PR TITLE
Feat: 게시글 좋아요 기능(#126)

### DIFF
--- a/src/components/common/Post.jsx
+++ b/src/components/common/Post.jsx
@@ -8,6 +8,7 @@ import postMenu from "../../assets/post_menu.svg";
 import nonLikeIcon from "../../assets/empty_likeBtn.svg";
 import likeIcon from "../../assets/post_fullLikeBtn.svg";
 
+
 const getElapsedTime = (createdAt) => {
   const currentTime = new Date();
   const createdDateTime = new Date(createdAt);
@@ -54,6 +55,11 @@ export default function Post({
 }) {
   const elapsedTimeString = getElapsedTime(createdAt);
   console.log("postId 값:", postId);
+  const [heartValue, setHeartValue] = useState(heartCount);
+  const getHeartData = () => {
+    setHeartValue(prev => prev += 1);
+
+  };
   return (
     <PostOuter>
       <PostTop>
@@ -76,8 +82,8 @@ export default function Post({
         <div>
           <span>{elapsedTimeString}</span>
           <div className="like_wrap">
-            <span>{heartCount}</span>
-            <PostLikeBtn postId={postId}/>
+            <span>{heartValue}</span>
+            <PostLikeBtn postId={postId} getHeartData={getHeartData}/>
           </div>
         </div>
       </PostContent>

--- a/src/components/common/PostLikeBtn.jsx
+++ b/src/components/common/PostLikeBtn.jsx
@@ -10,26 +10,35 @@ import nonLikeIcon from "../../assets/empty_likeBtn.svg";
 import likeIcon from "../../assets/post_fullLikeBtn.svg";
 
 // 기능 구현된거 없어요!!
-function PostLikeBtn({ postId }) {
+function PostLikeBtn({ postId, getHeartData }) {
   const [token] = useRecoilState(loginToken);
   // const [liked, setLiked] = useRecoilState(likedState);
   const [liked, setLiked] = useState(false);
   
   const [heartCount, setHeartCount] = useState(0); 
-  const [hearted, sethearted] = useState(postId)
+
+  const initialHearted = localStorage.getItem(`hearted_${postId}`) === "true";
+  const [hearted, sethearted] = useState(initialHearted);
+  const [heartValue, setHeartValue] = useState(0);
+
+  // const [hearted, sethearted] = useState(postId)
 
   console.log(hearted)
 
 
   const handleLike = async () => {
     try {
-      const response = await likeAPI(token,hearted);
+      const response = await likeAPI(token,postId);
       console.log("likeAPI 응답:", response);
       if (response) {
         setLiked(!liked);
         setHeartCount(response.post.heartCount); // heartCount 업데이트
         sethearted(response.post.hearted);
+        
+        localStorage.setItem(`hearted_${postId}`, response.post.hearted);
         console.log(response)
+        getHeartData();
+
       }
     } catch (error) {
       console.log("좋아요 API 에러가 발생했습니다", error);
@@ -40,9 +49,13 @@ function PostLikeBtn({ postId }) {
     sethearted(hearted);
   }, [hearted]);
 
+  useEffect(() => {
+    setHeartCount(heartCount);
+  }, [hearted]);
+
 
   return (
-    <Button liked={liked} onClick={handleLike} >
+    <Button liked={hearted} onClick={handleLike} >
   </Button>
   );
 }
@@ -62,4 +75,3 @@ const Button = styled.button`
 //   content: ${(props) =>
 //     props.liked ? `url(${likeIcon})` : `url(${nonLikeIcon})`};
 // `;
-

--- a/src/pages/PostPosting.jsx
+++ b/src/pages/PostPosting.jsx
@@ -43,7 +43,7 @@ export default function PostPosting() {
     const response = await postingAPI(ProductData, token);
 
     if (response.hasOwnProperty("post"))
-      navigate(`/main/`);
+      navigate(`/profile/`);
       console.log(response)
   };
   


### PR DESCRIPTION
- 이미지 초기화 : API hearted, 재랜더링시 이미지 초기화 문제 -> 페이지 렌더링과 데이터 받아오는 작업이 동시에 이루어질 경우, API로부터 데이터를 받아오는 것이 완료되기 전에 페이지가 렌더링되어 초기 설정값으로 보이게 될 수 있기때문. 로컬스토리지에 저장 후 사용하여 해결
- 카운트 랜더링 후 적용 문제 : response.post.heartCount로 가져오기만하고 다시 반영해서 post 컴포넌트에 쏴주는 부분이 없었음. 좋아요 버튼에서 프롭스로 값을 넘겨준 후 post에서 +1해서 반영. API 상에서는 이미 +1 되어있는 채기 때문에 새로고침해도 값이 자동으로 더해지지 않음