### PR TITLE
Feat: 프로필에서 이미지 오류해결, API 연동, 이미지 로딩중 업로드 방지(#190)

### DIFF
--- a/src/components/UpdateProfile.jsx
+++ b/src/components/UpdateProfile.jsx
@@ -24,8 +24,6 @@ export default function UpdateProfile({ handleSaveClick, profileData, handleInpu
     setIsImageEdit(updateImageUrl);
   }, [updateImageUrl, setIsImageEdit]);
 
-  console.log(BASE_URL + profileSelectedImage);
-
   return (
     <>
       <ProfileDiv>

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -21,7 +21,6 @@ export default function Card({
 }) {
   const myaccount_name = useRecoilValue(accountname);
   const temp = useParams();
-  const BASE_URL = "https://api.mandarin.weniv.co.kr/";
   const account_name = temp.account_name ? temp.account_name : myaccount_name;
   const [isLocalNavOpen, setIsLocalNavOpen] = useState(false);
 
@@ -33,7 +32,7 @@ export default function Card({
     <Article>
       <ArticleTop>
         <ProfileUI
-          user_profile={BASE_URL + profile}
+          user_profile={profile}
           user_name={name}
           user_email={email} 
           card="true"

--- a/src/components/common/Post.jsx
+++ b/src/components/common/Post.jsx
@@ -78,7 +78,7 @@ export default function Post({
     <PostOuter>
       <PostTop>
         <ProfileUI
-          user_profile={BASE_URL + profileImage}
+          user_profile={profileImage}
           user_name={username}
           user_email={email}
           mainprofile={false}

--- a/src/pages/profile/IntroUI.jsx
+++ b/src/pages/profile/IntroUI.jsx
@@ -7,11 +7,11 @@ export default function IntroUI({ profileData, setIsEditing }) {
   const handleEditClick = () => {
     setIsEditing(true);
   };
-  const BASE_URL = "https://api.mandarin.weniv.co.kr/";
+
   return (
     <>
       <IntroWrap>
-        <img src={BASE_URL + profileData.user.image} alt="유저 프로필 이미지" />
+        <img src={profileData.user.image} alt="유저 프로필 이미지" />
         <strong>{profileData.user.username}</strong>
         <p>{profileData.user.accountname}</p>
       </IntroWrap>

--- a/src/pages/profile/Profile.jsx
+++ b/src/pages/profile/Profile.jsx
@@ -1,21 +1,19 @@
-import React, { useEffect, useState } from 'react'
-import styled from 'styled-components';
-import { useRecoilValue } from 'recoil';
-import Layout from '../../layout/Layout';
-import loginToken from '../../recoil/loginToken';
-import profileAPI from '../../api/profile';
-import ProfileSkeleton from '../../style/skeletonUI/skeletonPage/ProfileSkeleton';
-import ProfileLeftUI from './ProfileLeftUI';
-import ProfileRightUI from './ProfileRightUI';
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { useRecoilValue } from "recoil";
+import Layout from "../../layout/Layout";
+import loginToken from "../../recoil/loginToken";
+import profileAPI from "../../api/profile";
+import ProfileSkeleton from "../../style/skeletonUI/skeletonPage/ProfileSkeleton";
+import ProfileLeftUI from "./ProfileLeftUI";
+import ProfileRightUI from "./ProfileRightUI";
 
 export default function Profile() {
-  // 리코일 값 불러오기
-  const token = useRecoilValue(loginToken);
-
   // 프로필 정보 불러오기
+  const token = useRecoilValue(loginToken);
   const [profileData, setProfileData] = useState(null);
-
   const [loading, setLoading] = useState(true);
+  const [fetchProfile, setFetchProfile] = useState(true);
 
   // 프로필 정보 불러오기
   useEffect(() => {
@@ -24,15 +22,16 @@ export default function Profile() {
         const response = await profileAPI(token);
         setProfileData(response);
         setLoading(false);
+        setFetchProfile(false);
       } catch (error) {
-        console.error("Account API 에러가 발생했습니다", error);
+        console.error("Profile API 에러가 발생했습니다", error);
       }
     };
-    console.log("프로필",profileData)
-    fetchProfileData();
-  }, []);
 
-  console.log(token);
+    if (fetchProfile) {
+      fetchProfileData();
+    }
+  }, [setFetchProfile, fetchProfile, setProfileData, setLoading]);
 
   return (
     <Layout reduceTop="true">
@@ -45,13 +44,14 @@ export default function Profile() {
               setLoading={setLoading}
               profileData={profileData}
               setProfileData={setProfileData}
+              setFetchProfile={setFetchProfile}
             />
             <ProfileRightUI />
           </>
         )}
       </ProfileWrap>
     </Layout>
-  )
+  );
 }
 
 const ProfileWrap = styled.div`
@@ -65,7 +65,7 @@ const ProfileWrap = styled.div`
   position: relative;
 
   &::before {
-    content: '';
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
@@ -73,4 +73,4 @@ const ProfileWrap = styled.div`
     height: 330px;
     background: #000;
   }
-`
+`;

--- a/src/pages/profile/ProfileLeftUI.jsx
+++ b/src/pages/profile/ProfileLeftUI.jsx
@@ -1,12 +1,22 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components';
 import UpdateProfile from './UpdateProfile';
 import IntroUI from './IntroUI';
 import FollowUI from './FollowUI';
 
-export default function ProfileLeftUI({ profileData, setProfileData }) {
+export default function ProfileLeftUI({ 
+  profileData, 
+  setProfileData,
+  setFetchProfile,
+}) {
   // 프로필 정보 수정
   const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setFetchProfile(true)
+    }
+  }, [isEditing, setFetchProfile])
 
   return (
     <>

--- a/src/pages/profile/UpdateProfile.jsx
+++ b/src/pages/profile/UpdateProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components';
 import PlusBtnImg from "../../assets/add_button.svg";
 import { useRecoilValue } from 'recoil';
@@ -7,23 +7,33 @@ import PostImageAPI from '../../api/UploadImage';
 import updateProfile from './../../api/updateProfile';
 import { InputBox } from '../../components/common/Input';
 import Button from '../../components/common/Button';
+import profileAPI from '../../api/profile';
 
 export default function UpdateProfile({ profileData, setIsEditing, setProfileData }) {
   // 리코일 값 불러오기
   const token = useRecoilValue(loginToken);
+  console.log("업데이트",profileData)
 
   // 프로필 이미지 업로드
   const [changeImageURL, setChangeImageURL] = useState(profileData.user.image);
+  const [isImageUpload, setIsImageUpload] = useState(false)
   const [userName, setUserName] = useState(profileData.user.username);
   const [intro, setIntro] = useState(profileData.user.intro);
+  const [postChangeImg, setPostChangeImg] = useState({
+    user: {
+      image: changeImageURL
+    }
+  })
 
   // 이미지 fetch
   const BASE_URL = "https://api.mandarin.weniv.co.kr/";
   const handleImageChange = async (e) => {
+    setIsImageUpload(true)
     const file = e.target.files[0];
     const imgSrc = await PostImageAPI(file);
 
     setChangeImageURL(BASE_URL + imgSrc);
+    setIsImageUpload(false)
   };
 
   // 저장 버튼 클릭 시 수정된 API에 데이터 전달
@@ -39,7 +49,7 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
         intro: intro
       },
     };
-
+    
     setProfileData(updatedProfileData);
     updateProfile(updatedProfileData, token);
     setIsEditing(false);
@@ -59,6 +69,16 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
       setIntro(value)
     }
   }
+
+  useEffect(() => {
+    const postImage = async (token) => {
+      const response = await profileAPI(token);
+    };
+
+    if (postChangeImg) {
+      postImage(postChangeImg, token);
+    }
+  }, [postChangeImg]);
 
   return (
     <>
@@ -124,6 +144,7 @@ export default function UpdateProfile({ profileData, setIsEditing, setProfileDat
           padding="14px 0"
           fontSize="16px"
           br="none"
+          disabled={isImageUpload}
         />
       </Form>
     </>


### PR DESCRIPTION
- 프로필에서 수정 시 이미지 깨짐현상 : 수정 후 프로필 API에 쏴줌
- 수정할 때 쏴주고 다시 리패치해서 수정 후 적용
- 이미지가 서버에 업로드 되기 전에 완료버튼을 누를 시에 수정 전 이미지가 업로드 되는 문제 -> 로딩중 버튼 disabled 처리
- right단에서 post와 product API 에서 이미지 데이터 불러옴 -> 컨텐츠 이미지는 BASE_URL을 붙여줘야하지만 user{}에서는 이미 붙여져서 와서 중복되는 BASE_URL 삭제
