### PR TITLE
Refactor: 장바구니 마크업 수정(#272)

### DIFF
--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -1,16 +1,17 @@
 import React from "react";
 import { useRecoilState, useResetRecoilState } from "recoil";
-import { cartItemsState } from "../recoil/cartItemState";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { cartItemsState } from "../recoil/cartItemState";
+import checkImageUrl from "../components/common/checkImageUrl";
+
 import Button from "../components/common/Button/Button";
 import Layout from "../layout/Layout";
-import { useNavigate } from "react-router-dom";
 
 import cartNullIcon from "../assets/cart_null_icon.svg";
-import defaultImage from "../assets/profile_img_def.svg";
 import iconClose from "../assets/icon_close.svg";
-import checkImageUrl from "../components/common/checkImageUrl";
+
 
 export default function Cart() {
   const [cartItem, setCartItem] = useRecoilState(cartItemsState);
@@ -46,7 +47,6 @@ export default function Cart() {
     cartRest();
   };
 
-  // 숫자 세자리 수마다 컴마 찍어주는 함수
   const priceDivide = (price) => {
     return price.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
   };
@@ -69,7 +69,7 @@ export default function Cart() {
                   <CartUserInfo>
                     <img
                       src={checkImageUrl(item.userImage, "profile")}
-                      alt="유저 이미지"
+                      alt="판매자 프로필 이미지"
                     />
                     <strong>{item.userName}</strong>
                     <button onClick={() => removeItem(item.id)}>
@@ -144,7 +144,7 @@ export default function Cart() {
   );
 }
 
-const CartWrap = styled.div`
+const CartWrap = styled.section`
   display: flex;
   justify-content: space-between;
   gap: 64px;


### PR DESCRIPTION
### Cart
1. 장바구니의 큰 틀 div -> section 수정
```Js
const CartWrap = styled.section
```
2. 이미지 alt 변경
```Js
<img
  src={checkImageUrl(item.userImage, "profile")}
  alt="판매자 프로필 이미지"
/>
```
3. 큰 모니터로 봤을 때 장바구니 페이지의 푸터가 공중에 띄워져있는 이슈 확인
![스크린샷 2023-07-19 오후 6 18 04](https://github.com/FRONTENDSCHOOL5/final-10-Goodi/assets/97887376/e6f240fd-34b3-4a7a-974e-f14d3d15663b)


푸터가 레이아웃으로 잡혀있어 장바구니 페이지에 맞게 수정하면 다른 페이지에서 깨지는 문제가 있어, 일단은 수정을 보류해놓았습니다. 추후 반응형 리팩토링 때 확인해도 좋을 것 같습니다.