### PR TITLE
Refactor: detail 페이지 웹접근성을 고려한 마크업 수정(#272)

### DIFF
--- a/src/components/Count.jsx
+++ b/src/components/Count.jsx
@@ -6,9 +6,14 @@ import { useState } from "react";
 import PlusIcon from "../assets/icon_plus_black.svg";
 import MinusIcon from "../assets/icon_minus_black.svg";
 
-export default function Count({ count, setCount, getPrice, price, productPrice, stock }) {
-
-
+export default function Count({
+  count,
+  setCount,
+  getPrice,
+  price,
+  productPrice,
+  stock,
+}) {
   // 카운트 증가 함수
   const increaseHandler = () => {
     setCount(count + 1);
@@ -62,6 +67,10 @@ const Countwrap = styled.section`
     cursor: pointer;
     text-align: center;
     border-radius: 3px;
+  }
+
+  & button:focus {
+    outline: 1px solid #ff1515;
   }
 
   & button img {

--- a/src/components/DetailImage.jsx
+++ b/src/components/DetailImage.jsx
@@ -33,6 +33,7 @@ export default function DetailImage({ img }) {
 
   return (
     <ProductDetailImg>
+      <h3 className="a11y-hidden">제품 상세이미지</h3>
       <div className="top_img_wrap">
         <img
           className="common_banner"
@@ -41,7 +42,7 @@ export default function DetailImage({ img }) {
         />
         <img
           className="top_detail_img"
-          src={checkImageUrl(img[currentIndex], 'post')}
+          src={checkImageUrl(img[currentIndex], "post")}
           alt="상세 이미지"
         />
 
@@ -57,7 +58,7 @@ export default function DetailImage({ img }) {
               key={index}
               className={`detail_img ${index === currentIndex ? "active" : ""}`}
               onClick={() => handleSlide(index)}
-              src={checkImageUrl(el, 'post')}
+              src={checkImageUrl(el, "post")}
               alt="상세 이미지"
             />
           );
@@ -67,7 +68,7 @@ export default function DetailImage({ img }) {
   );
 }
 
-const ProductDetailImg = styled.section`
+const ProductDetailImg = styled.div`
   width: 40%;
 
   .top_img_wrap {
@@ -93,6 +94,10 @@ const ProductDetailImg = styled.section`
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+  }
+
+  & button:focus {
+    outline: 1px solid #ff1515;
   }
 
   .bottom_img_wrap {

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -5,7 +5,7 @@ import { useRecoilState, useRecoilValue } from "recoil";
 
 //component
 import Layout from "../layout/Layout";
-import DetailImage from './../components/DetailImage';
+import DetailImage from "./../components/DetailImage";
 import Count from "../components/Count";
 import ProfileUI from "../components/ProfileUI";
 import Button from "../components/common/Button/Button";
@@ -52,26 +52,29 @@ export default function Detail() {
       productPrice: productData.price,
       productImage: productData.itemImage.split(",")[0],
       productCount: count,
-    }
+    };
 
     setToast(true);
 
-    const existingItem = cartItem.find((cartItem) => cartItem.id === newItem.id);
+    const existingItem = cartItem.find(
+      (cartItem) => cartItem.id === newItem.id
+    );
 
     if (existingItem) {
       // 이미 장바구니에 있는 상품인 경우
       const updatedItems = cartItem.map((cartItem) =>
-        cartItem.id === newItem.id ? { ...cartItem, productCount: cartItem.productCount + count } : cartItem
+        cartItem.id === newItem.id
+          ? { ...cartItem, productCount: cartItem.productCount + count }
+          : cartItem
       );
       setCartItem(updatedItems);
     } else {
       // 장바구니에 없는 상품인 경우
       setCartItem([...cartItem, newItem]);
     }
-  }
+  };
 
   const myaccount_name = useRecoilValue(accountname);
-  // const temp = useParams();
   const account_name = id.account_name ? id.account_name : myaccount_name;
 
   // product 정보 API에서 받아오기
@@ -116,7 +119,10 @@ export default function Detail() {
               <div className="product_detail_top">
                 <ProfileUI
                   key={productData.author._id}
-                  user_profile={checkImageUrl(productData.author.image, 'profile')}
+                  user_profile={checkImageUrl(
+                    productData.author.image,
+                    "profile"
+                  )}
                   user_name={productData.author.username}
                   user_email={productData.author.accountname}
                   account_name={account_name}
@@ -128,15 +134,15 @@ export default function Detail() {
               <DeliveryDescription>
                 <div className="delivery_date">
                   <img src={DeliveryIcon} alt="박스 아이콘" />
-                  <h4 className="delivery_price_subtitle">배송 기간</h4>
+                  <h3 className="delivery_price_subtitle">배송 기간</h3>
                   <p className="delivery_price_text">
-                    지금 주문하면 <strong>3일 이내</strong> 출고 예정 (주말, 공휴일
-                    제외)
+                    지금 주문하면 <strong>3일 이내</strong> 출고 예정 (주말,
+                    공휴일 제외)
                   </p>
                 </div>
                 <div className="delivery_price">
                   <img src={MoneyIcon} alt="동전 아이콘" />
-                  <h4 className="delivery_price_subtitle">배송비</h4>
+                  <h3 className="delivery_price_subtitle">배송비</h3>
                   <p className="delivery_price_text">
                     구디 제품 80,000원 이상 구매시 무료배송
                     <br />
@@ -144,7 +150,7 @@ export default function Detail() {
                   </p>
                 </div>
               </DeliveryDescription>
-              <h4 className="product_count_subtitle">수량</h4>
+              <h3 className="product_count_subtitle">수량</h3>
               <Count
                 count={count}
                 setCount={setCount}
@@ -154,7 +160,7 @@ export default function Detail() {
               />
               <hr />
               <ProductPrice>
-                <h4 className="product_price_subtitle">총 결제 금액</h4>
+                <h3 className="product_price_subtitle">총 결제 금액</h3>
                 <p className="product_price">
                   <strong>{priceDivide(price)}</strong>원
                 </p>
@@ -178,7 +184,7 @@ export default function Detail() {
                   type="button"
                   bg="black"
                   br="none"
-                  onClick={() => navigate('/chat')}
+                  onClick={() => navigate("/chat")}
                 />
               </ButtonWrap>
             </ProductDetail>
@@ -189,13 +195,13 @@ export default function Detail() {
   );
 }
 
-const DetailWrap = styled.div`
+const DetailWrap = styled.section`
   margin: 0 60px 120px 80px;
   display: flex;
   gap: 5%;
 `;
 
-const ProductDetail = styled.section`
+const ProductDetail = styled.div`
   width: 55%;
 
   .product_detail_top {
@@ -243,7 +249,7 @@ const DeliveryDescription = styled.section`
     margin-top: -7px;
   }
 
-  & div h4 {
+  & div h3 {
     width: 15%;
     font-size: 16px;
     font-family: var(--font--Bold);


### PR DESCRIPTION
1. 의미없는 주석 삭제
2. DetailImage 에서 왼쪽, 오른쪽 버튼에 과 Count 단의 수량 추가 버튼의 포커스가 사용자에게 보이지 않아서 outline style 추가

3. 스크린리더기로 읽을시 제품의 상세이미지라는 제목이 빠져있어 어떤걸 보여주는지 알수 없으므로 h3태그 추가

```JavaScript
<h3 className="a11y-hidden">제품 상세이미지</h3>
```
4. ProductDetail 은 전체 상세페이지 section 하위태그로 단지 그룹으로 묶어주기 위한요소이므로 div 태그로 변경
5. 배송기간, 배송비, 수량, 총 결제 금액 제품상세 내용들인데 해당 페이지의 제목인 제품명 h2 다음으로 h3가 비고 h4태그로 되어 있어 h3태그로 변경

<img width="213" alt="스크린샷 2023-07-19 오후 10 57 18" src="https://github.com/FRONTENDSCHOOL5/final-10-Goodi/assets/124513796/8d28bfcc-1cd8-49c4-b95a-a962cd4077a1">


